### PR TITLE
Draft #2

### DIFF
--- a/srfi-168.html
+++ b/srfi-168.html
@@ -130,18 +130,6 @@
     <p>Return a <code>#t</code> if <code>OBJECT</code> is an nstore
         object and <code>#f</code> otherwise.</p>
 
-    <h3 id="close-nstore"><code>(nstore-close nstore)</code></h3>
-
-    <p>Close <code>NSTORE</code>.</p>
-
-    <h3 id="nstore-everything"><code>(nstore-everything database nstore)</code></h3>
-
-    <p>Return the items that are in <code>NSTORE</code> as an SRFI-158
-        generator of lists.  This is a procedure for debugging.  Actual
-        querying of the database must be done with
-        <code>nstore-from</code> and <code>nstore-where</code> procedures.
-        The stream must be ordered lexicographically.</p>
-
     <h3 id="nstore-ask"><code>(nstore-ask? some nstore . items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -192,12 +192,6 @@
     <p>The returned generator is called the <em>seed</em> generator
       because it doesn’t rely on an existing generator of bindings.</p>
 
-    <p><strong>Note:</strong> Making the stream ordered, in this case,
-      might not be worthwhile.  If there is an interest, it might be
-      the subject of a future SRFI.  Also, it will be required to
-      define an efficient mapping that remembers key-value insertion
-      order which will allow defining a total order between bindings.</p>
-
     <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -177,17 +177,17 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore pattern [config]) → generator</code></h3>
-
-    <p>Must be decorated with <code>transactional</code> so that it is
-      possible to pass a transaction or a database object as first
-      argument.</p>
+    <h3 id="nstore-from"><code>(nstore-from transaction nstore pattern [config]) → generator</code></h3>
 
     <p>Return a generator of bindings where variables (in the sense of
       <code>nstore-var?</code>) of <code>PATTERN</code> are bound against one or
       more <em>matching</em> tuples from the store associated with
-      <code>SOME</code>.  The implementation must return a
+      <code>TRANSACTION</code>.  The implementation must return a
       SRFI-158 generator of SRFI-146 hash mappings.</p>
+
+    <p>Note: the generator is valid as long as the transaction is running.
+        If the transaction is commited the generator will not be able to
+        proceed.</p>
 
     <p>The returned generator is called the <em>seed</em> generator
         because it doesn’t rely on an existing generator of bindings.</p>
@@ -215,21 +215,20 @@
         </tbody>
     </table>
 
-
-    <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
-
-    <p>Must be decorated with <code>transactional</code> so that it is
-      possible to pass a transaction or a database object as first
-      argument.</p>
+    <h3 id="nstore-where"><code>(nstore-where transaction nstore pattern) → procedure → generator</code></h3>
 
     <p>Return a procedure that takes a generator of bindings as
       argument and returns a generator of bindings where variables of
       <code>PATTERN</code> are bound to one or more <em>matching</em>
       tuples from the store associated with
-      <code>SOME</code>.</p>
+      <code>TRANSACTION</code>.</p>
 
     <p>Note: The generator returned by <code>nstore-where</code> is flat.  It
         is NOT a generator of generators.</p>
+
+    <p>Note: the generator is valid as long as the transaction is running.
+        If the transaction is commited the generator will not be able to
+        proceed.</p>
 
     <h3 id="nstore-select"><code>(nstore-select &lt;from&gt; &lt;where&gt; ...)</code> syntax</h3>
 

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from some nstore pattern config) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -193,10 +193,37 @@
       because it doesn’t rely on an existing generator of bindings.</p>
 
     <p><strong>Note:</strong> Making the stream ordered, in this case,
-      might not be worthwhile.  If there is an interest, it might be
-      the subject of a future SRFI.  Also, it will be required to
-      define an efficient mapping that remembers key-value insertion
-      order which will allow defining a total order between bindings.</p>
+        might not be worthwhile.  If there is an interest, it might be
+        the subject of a future SRFI.  Also, it will be required to
+        define an efficient mapping that remembers key-value insertion
+        order which will allow defining a total order between bindings.</p>
+
+    <p><code>CONFIG</code> might contain the following options:</p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>key</th>
+                <th>description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>'limit</code></td>
+                <td>indicates the maximum number of tuples to return.</td>
+            </tr>
+            <tr>
+                <td><code>'reverse?</code></td>
+                <td>whether tuples will be returned in reverse
+                    lexicographical order beginning at the end of the
+                    range.</td>
+            </tr>
+            <tr>
+                <td><code>'offset</code></td>
+                <td>specify how many tuples be skipped.</td>
+            </tr>
+        </tbody>
+    </table>
 
     <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -130,34 +130,34 @@
     <p>Return a <code>#t</code> if <code>OBJECT</code> is an nstore
         object and <code>#f</code> otherwise.</p>
 
-    <h3 id="nstore-ask"><code>(nstore-ask? transaction nstore items)</code></h3>
+    <h3 id="nstore-ask"><code>(nstore-ask? some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
         that it is possible to pass a transaction or a database object
         as first argument.</p>
 
     <p>Return <code>#t</code> if <code>ITEMS</code> is present in the
-      store associated with <code>TRANSACTION</code>.  Otherwise,
+      store associated with <code>SOME</code>.  Otherwise,
       return <code>#f</code>.</p>
 
-    <h3 id="nstore-add"><code>(nstore-add! transaction nstore items)</code></h3>
+    <h3 id="nstore-add"><code>(nstore-add! some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
       as first argument.</p>
 
     <p>Add <code>ITEMS</code> to the store associated with
-      <code>TRANSACTION</code>.  If <code>ITEMS</code> is already in the
+      <code>SOME</code>.  If <code>ITEMS</code> is already in the
       associated store, do nothing.  Return value is unspecified.</p>
 
-    <h3 id="nstore-rm"><code>(nstore-rm! transaction nstore items)</code></h3>
+    <h3 id="nstore-rm"><code>(nstore-rm! some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
       as first argument.</p>
 
     <p>Remove <code>ITEMS</code> from the store associated with
-      <code>TRANSACTION</code>.  Do nothing if <code>ITEMS</code>
+      <code>SOME</code>.  Do nothing if <code>ITEMS</code>
       is not in the store.  Return value is unspecified.</p>
 
     <h3 id="nstore-var"><code>(nstore-var name)</code></h3>
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from transaction nstore pattern) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -186,7 +186,7 @@
     <p>Return a generator of bindings where variables (in the sense of
       <code>nstore-var?</code>) of <code>PATTERN</code> are bound against one or
       more <em>matching</em> tuples from the store associated with
-      <code>TRANSACTION</code>.  The implementation must return a
+      <code>SOME</code>.  The implementation must return a
       SRFI-158 generator of SRFI-146 hash mappings.</p>
 
     <p>The returned generator is called the <em>seed</em> generator
@@ -198,7 +198,7 @@
       define an efficient mapping that remembers key-value insertion
       order which will allow defining a total order between bindings.</p>
 
-    <h3 id="nstore-where"><code>(nstore-where transaction nstore pattern) → procedure → generator</code></h3>
+    <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -208,7 +208,7 @@
       argument and returns a generator of bindings where variables of
       <code>PATTERN</code> are bound to one or more <em>matching</em>
       tuples from the store associated with
-      <code>TRANSACTION</code>.</p>
+      <code>SOME</code>.</p>
 
     <p>Note: The generator returned by <code>nstore-where</code> is flat.  It
         is NOT a generator of generators.</p>

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from some nstore pattern [config]) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -190,7 +190,31 @@
       SRFI-158 generator of SRFI-146 hash mappings.</p>
 
     <p>The returned generator is called the <em>seed</em> generator
-      because it doesn’t rely on an existing generator of bindings.</p>
+        because it doesn’t rely on an existing generator of bindings.</p>
+
+    <p><code>CONFIG</code> is an optional association list that allows
+        to configure the returned generator. It takes the following
+        options:</p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>key</th>
+                <th>description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>'offset</code></td>
+                <td>specify how many bindings must be skipped.</td>
+            </tr>
+            <tr>
+                <td><code>'limit</code></td>
+                <td>indicates the maximum number of bindings to return.</td>
+            </tr>
+        </tbody>
+    </table>
+
 
     <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -130,34 +130,34 @@
     <p>Return a <code>#t</code> if <code>OBJECT</code> is an nstore
         object and <code>#f</code> otherwise.</p>
 
-    <h3 id="nstore-ask"><code>(nstore-ask? some nstore items)</code></h3>
+    <h3 id="nstore-ask"><code>(nstore-ask? transaction nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
         that it is possible to pass a transaction or a database object
         as first argument.</p>
 
     <p>Return <code>#t</code> if <code>ITEMS</code> is present in the
-      store associated with <code>SOME</code>.  Otherwise,
+      store associated with <code>TRANSACTION</code>.  Otherwise,
       return <code>#f</code>.</p>
 
-    <h3 id="nstore-add"><code>(nstore-add! some nstore items)</code></h3>
+    <h3 id="nstore-add"><code>(nstore-add! transaction nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
       as first argument.</p>
 
     <p>Add <code>ITEMS</code> to the store associated with
-      <code>SOME</code>.  If <code>ITEMS</code> is already in the
+      <code>TRANSACTION</code>.  If <code>ITEMS</code> is already in the
       associated store, do nothing.  Return value is unspecified.</p>
 
-    <h3 id="nstore-rm"><code>(nstore-rm! some nstore items)</code></h3>
+    <h3 id="nstore-rm"><code>(nstore-rm! transaction nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
       as first argument.</p>
 
     <p>Remove <code>ITEMS</code> from the store associated with
-      <code>SOME</code>.  Do nothing if <code>ITEMS</code>
+      <code>TRANSACTION</code>.  Do nothing if <code>ITEMS</code>
       is not in the store.  Return value is unspecified.</p>
 
     <h3 id="nstore-var"><code>(nstore-var name)</code></h3>
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from transaction nstore pattern) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -186,7 +186,7 @@
     <p>Return a generator of bindings where variables (in the sense of
       <code>nstore-var?</code>) of <code>PATTERN</code> are bound against one or
       more <em>matching</em> tuples from the store associated with
-      <code>SOME</code>.  The implementation must return a
+      <code>TRANSACTION</code>.  The implementation must return a
       SRFI-158 generator of SRFI-146 hash mappings.</p>
 
     <p>The returned generator is called the <em>seed</em> generator
@@ -198,7 +198,7 @@
       define an efficient mapping that remembers key-value insertion
       order which will allow defining a total order between bindings.</p>
 
-    <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
+    <h3 id="nstore-where"><code>(nstore-where transaction nstore pattern) → procedure → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -208,7 +208,7 @@
       argument and returns a generator of bindings where variables of
       <code>PATTERN</code> are bound to one or more <em>matching</em>
       tuples from the store associated with
-      <code>SOME</code>.</p>
+      <code>TRANSACTION</code>.</p>
 
     <p>Note: The generator returned by <code>nstore-where</code> is flat.  It
         is NOT a generator of generators.</p>

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -97,7 +97,7 @@
       Ordered Key Value Store SRFI so that it possible to swap one
       storage engine with another seamlessly.</p>
 
-    <h3 id="nstore-engine"><code>(nstore-engine ref set! rm! range)</code></h3>
+    <h3 id="nstore-engine"><code>(nstore-engine ref set! rm! prefix)</code></h3>
 
     <p>Return an object suitable to pass to the <code>nstore</code>
         procedure.</p>
@@ -114,7 +114,7 @@
       will always contain tuples of the same length.  Tuples are
       always passed as rest arguments to the database procedures.</p>
 
-    <h3 id="nstore"><code>(nstore database engine . items)</code></h3>
+    <h3 id="nstore"><code>(nstore engine prefix . items)</code></h3>
 
     <p>Return an <code>nstore</code> object. <code>ENGINE</code> is
         described above.  <code>DATABASE</code> is an okvs object as

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -114,7 +114,7 @@
       will always contain tuples of the same length.  Tuples are
       always passed as rest arguments to the database procedures.</p>
 
-    <h3 id="nstore"><code>(nstore engine prefix . items)</code></h3>
+    <h3 id="nstore"><code>(nstore engine prefix items)</code></h3>
 
     <p>Return an <code>nstore</code> object. <code>ENGINE</code> is
         described above.  <code>DATABASE</code> is an okvs object as
@@ -130,7 +130,7 @@
     <p>Return a <code>#t</code> if <code>OBJECT</code> is an nstore
         object and <code>#f</code> otherwise.</p>
 
-    <h3 id="nstore-ask"><code>(nstore-ask? some nstore . items)</code></h3>
+    <h3 id="nstore-ask"><code>(nstore-ask? some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
         that it is possible to pass a transaction or a database object
@@ -140,7 +140,7 @@
       store associated with <code>SOME</code>.  Otherwise,
       return <code>#f</code>.</p>
 
-    <h3 id="nstore-add"><code>(nstore-add! some nstore . items)</code></h3>
+    <h3 id="nstore-add"><code>(nstore-add! some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
@@ -150,7 +150,7 @@
       <code>SOME</code>.  If <code>ITEMS</code> is already in the
       associated store, do nothing.  Return value is unspecified.</p>
 
-    <h3 id="nstore-rm"><code>(nstore-rm! some nstore . items)</code></h3>
+    <h3 id="nstore-rm"><code>(nstore-rm! some nstore items)</code></h3>
 
     <p>Must be decorated with SRFI-167 <code>transactional</code> so
       that it is possible to pass a transaction or a database object
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore . pattern) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -198,7 +198,7 @@
       define an efficient mapping that remembers key-value insertion
       order which will allow defining a total order between bindings.</p>
 
-    <h3 id="nstore-where"><code>(nstore-where some nstore . pattern) → procedure → generator</code></h3>
+    <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first

--- a/srfi-168.html
+++ b/srfi-168.html
@@ -177,7 +177,7 @@
       If <code>VARIABLE</code> is not a variable is the sense of
       <code>var?</code>, the returned value is unspecified.</p>
 
-    <h3 id="nstore-from"><code>(nstore-from some nstore pattern config) → generator</code></h3>
+    <h3 id="nstore-from"><code>(nstore-from some nstore pattern) → generator</code></h3>
 
     <p>Must be decorated with <code>transactional</code> so that it is
       possible to pass a transaction or a database object as first
@@ -193,37 +193,10 @@
       because it doesn’t rely on an existing generator of bindings.</p>
 
     <p><strong>Note:</strong> Making the stream ordered, in this case,
-        might not be worthwhile.  If there is an interest, it might be
-        the subject of a future SRFI.  Also, it will be required to
-        define an efficient mapping that remembers key-value insertion
-        order which will allow defining a total order between bindings.</p>
-
-    <p><code>CONFIG</code> might contain the following options:</p>
-
-    <table>
-        <thead>
-            <tr>
-                <th>key</th>
-                <th>description</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><code>'limit</code></td>
-                <td>indicates the maximum number of tuples to return.</td>
-            </tr>
-            <tr>
-                <td><code>'reverse?</code></td>
-                <td>whether tuples will be returned in reverse
-                    lexicographical order beginning at the end of the
-                    range.</td>
-            </tr>
-            <tr>
-                <td><code>'offset</code></td>
-                <td>specify how many tuples be skipped.</td>
-            </tr>
-        </tbody>
-    </table>
+      might not be worthwhile.  If there is an interest, it might be
+      the subject of a future SRFI.  Also, it will be required to
+      define an efficient mapping that remembers key-value insertion
+      order which will allow defining a total order between bindings.</p>
 
     <h3 id="nstore-where"><code>(nstore-where some nstore pattern) → procedure → generator</code></h3>
 

--- a/srfi/nstore-tests.scm
+++ b/srfi/nstore-tests.scm
@@ -1,0 +1,130 @@
+(import (scheme base)
+        (scheme generator)
+        (cffi wiredtiger okvs)
+        (srfi :64)
+        (arew)
+        (prefix (arew filename) filename:)
+        (scheme process-context)
+        (scheme generator)
+        (scheme comparator)
+        (scheme mapping hash)
+        (cffi wiredtiger nstore))
+
+
+(define-syntax-rule (with-directory name body ...)
+  (begin
+    (when (filename:exists? name)
+      (filename:delete name))
+    (filename:make name)
+    (let ((out (begin body ...)))
+      (filename:delete name)
+      out)))
+
+(define-syntax-rule (test-check name expected computed)
+  (test-equal name expected (with-directory "wt" computed)))
+
+(test-begin "wiredtiger-nstore")
+
+(define (triplestore)
+  (let ((engine (nstore-engine okvs-ref okvs-set! okvs-rm! okvs-prefix)))
+    (nstore engine (list 42) '(uid key value))))
+
+(test-check "ask empty triplestore"
+  #f
+  (let ((okvs (okvs '((home . "wt") (create? . #t))))
+        (triplestore (triplestore)))
+    ;; ask
+    (let ((out (nstore-ask? okvs triplestore '("P4X432" blog/title "hyper.dev"))))
+      (okvs-close okvs)
+      out)))
+
+(test-check "add and ask triplestore"
+  #t
+  (let ((okvs (okvs '((home . "wt") (create? . #t))))
+        (triplestore (triplestore)))
+    ;; add
+    (nstore-add! okvs triplestore '("P4X432" blog/title "hyper.dev"))
+    ;; ask
+    (let ((out (nstore-ask? okvs triplestore '("P4X432" blog/title "hyper.dev"))))
+      (okvs-close okvs)
+      out)))
+
+(test-check "add, rm and ask triplestore"
+  #f
+  (let ((okvs (okvs '((home . "wt") (create? . #t))))
+        (triplestore (triplestore)))
+    ;; add!
+    (nstore-add! okvs triplestore '("P4X432" blog/title "hyper.dev"))
+    ;; remove!
+    (nstore-rm! okvs triplestore '("P4X432" blog/title "hyper.dev"))
+    ;; ask
+    (let ((out (nstore-ask? okvs triplestore '("P4X432" blog/title "hyper.dev"))))
+      (okvs-close okvs)
+      out)))
+
+(test-check "blog query post titles"
+  '("DIY a database" "DIY a full-text search engine")
+
+  (let ((okvs (okvs '((home . "wt") (create? . #t))))
+        (triplestore (triplestore)))
+    ;; add hyper.dev blog posts
+    (nstore-add! okvs triplestore '("P4X432" blog/title "hyper.dev"))
+    (nstore-add! okvs triplestore '("123456" post/title "DIY a database"))
+    (nstore-add! okvs triplestore '("123456" post/blog "P4X432"))
+    (nstore-add! okvs triplestore '("654321" post/title "DIY a full-text search engine"))
+    (nstore-add! okvs triplestore '("654321" post/blog "P4X432"))
+    ;; add dthompson.us blog posts
+    (nstore-add! okvs triplestore '("1" blog/title "dthompson.us"))
+    (nstore-add! okvs triplestore '("2" post/title "Haunt 0.2.4 released"))
+    (nstore-add! okvs triplestore '("2" post/blog "1"))
+    (nstore-add! okvs triplestore '("3" post/title "Haunt 0.2.3 released"))
+    (nstore-add! okvs triplestore '("3" post/blog "1"))
+    ;; query
+    (let ()
+      (define query
+        (okvs-transactional
+         (lambda (transaction blog/title)
+           (generator->list (nstore-select
+                             (nstore-from transaction triplestore
+                                          (list (nstore-var 'blog/uid)
+                                                'blog/title
+                                                blog/title))
+                             (nstore-where transaction triplestore
+                                           (list (nstore-var 'post/uid)
+                                                 'post/blog
+                                                 (nstore-var 'blog/uid)))
+                             (nstore-where transaction triplestore
+                                           (list (nstore-var 'post/uid)
+                                                 'post/title
+                                                 (nstore-var 'post/title))))))))
+      (let* ((out (query okvs "hyper.dev"))
+             (out (map (lambda (x) (hashmap-ref x 'post/title)) out)))
+        (okvs-close okvs)
+        out))))
+
+(test-check "nstore-from limit and offset"
+  '("hyperdev.fr")
+  (let ((okvs (okvs '((home . "wt") (create? . #t))))
+        (triplestore (triplestore)))
+    ;; add!
+    (nstore-add! okvs triplestore '("P4X432" blog/title "hyper.dev"))
+    (nstore-add! okvs triplestore '("P4X433" blog/title "hyperdev.fr"))
+    (nstore-add! okvs triplestore '("P4X434" blog/title "hypermove.net"))
+    ((okvs-transactional
+     (lambda (transaction)
+       (generator-map->list
+        (lambda (item) (hashmap-ref item 'title))
+        (nstore-from transaction triplestore (list (nstore-var 'uid)
+                                            'blog/title
+                                            (nstore-var 'title))
+                     `((limit . 1) (offset . 1))))))
+     okvs)))
+
+(test-end)
+
+
+(define xpass (test-runner-xpass-count (test-runner-current)))
+(define fail (test-runner-fail-count (test-runner-current)))
+(if (and (= xpass 0) (= fail 0))
+    (exit 0)
+    (exit 1))

--- a/srfi/nstore.scm
+++ b/srfi/nstore.scm
@@ -1,323 +1,339 @@
-(define-module (nstore))
-
-(export nstore-engine nstore nstore-ask? nstore-add! nstore-rm!
-        nstore-var nstore-var? nstore-var-name
-        nstore-from nstore-where nstore-select)
-
-(import (scheme assume))
-(import (scheme base))
-(import (scheme list))
-(import (scheme comparator))
-(import (scheme mapping hash))
-(import (scheme generator))
-
-(import (okvs))
-(import (pack))
-
-;; helper
-
-(define (permutations s)
-  ;; http://rosettacode.org/wiki/Permutations#Scheme
-  (cond
-   ((null? s) '(()))
-   ((null? (cdr s)) (list s))
-   (else ;; extract each item in list in turn and permutations the rest
-    (let splice ((l '()) (m (car s)) (r (cdr s)))
-      (append
-       (map (lambda (x) (cons m x)) (permutations (append l r)))
-       (if (null? r) '()
-           (splice (cons m l) (car r) (cdr r))))))))
-
-(define (combination k lst)
-  (cond
-   ((= k 0) '(()))
-   ((null? lst) '())
-   (else
-    (let ((head (car lst))
-          (tail (cdr lst)))
-      (append (map (lambda (y) (cons head y)) (combination (- k 1) tail))
-              (combination k tail))))))
-
-(define (combinations lst)
-  (if (null? lst) '(())
-      (let* ((head (car lst))
-             (tail (cdr lst))
-             (s (combinations tail))
-             (v (map (lambda (x) (cons head x)) s)))
-        (append s v))))
-
-;; make-indices will compute the minimum number of indices/tables
-;; required to bind any pattern in one hop. The math behind this
-;; computation is explained at:
+;; Copyright © 2019 Amirouche BOUBEKKI <amirouche at hyper dev>
 ;;
-;;   https://math.stackexchange.com/q/3146568/23663
+;;; Comment:
 ;;
-;; make-indices will return the minimum list of permutations in
-;; lexicographic order of the base index ie. (iota n) where n is
-;; the length of ITEMS ie. the n in nstore.
+;; - 2019/05: initial version
+;; - 2019/05: port to chez scheme
+;;
+(define-library (nstore)
 
-(define (prefix? lst other)
-  "Return #t if LST is prefix of OTHER"
-  (let loop ((lst lst)
-             (other other))
-    (if (null? lst)
-        #t
-        (if (= (car lst) (car other))
-            (loop (cdr lst) (cdr other))
-            #f))))
+  (export nstore-engine nstore nstore-ask? nstore-add! nstore-rm!
+          nstore-var nstore-var? nstore-var-name
+          nstore-from nstore-where nstore-select)
 
-(define (permutation-prefix? c o)
-  (any (lambda (p) (prefix? p o)) (permutations c)))
+  (import (only (chezscheme) assert))
+  (import (scheme base))
+  (import (scheme case-lambda))
+  (import (scheme list))
+  (import (scheme comparator))
+  (import (scheme mapping hash))
+  (import (scheme generator))
+  (import (cffi wiredtiger okvs))
+  (import (cffi wiredtiger pack))
 
-(define (ok? combinations candidate)
-  (every (lambda (c) (any (lambda (p) (permutation-prefix? c p)) candidate)) combinations))
+  (begin
 
-(define (findij L)
-  (let loop3 ((x L)
-              (y '()))
-    (if (or (null? x) (null? (cdr x)))
-        (values #f (append (reverse! y) x) #f #f)
-        (if (and (not (cdr (list-ref x 0))) (cdr (list-ref x 1)))
-            (values #t
-                    (append (cddr x) (reverse! y))
-                    (car (list-ref x 0))
-                    (car (list-ref x 1)))
-            (loop3 (cdr x) (cons (car x) y))))))
+    ;; helper
 
-(define (bool v)
-  (not (not v)))
+    (define (permutations s)
+      ;; http://rosettacode.org/wiki/Permutations#Scheme
+      (cond
+       ((null? s) '(()))
+       ((null? (cdr s)) (list s))
+       (else ;; extract each item in list in turn and permutations the rest
+        (let splice ((l '()) (m (car s)) (r (cdr s)))
+          (append
+           (map (lambda (x) (cons m x)) (permutations (append l r)))
+           (if (null? r) '()
+               (splice (cons m l) (car r) (cdr r))))))))
 
-(define (lex< a b)
-  (let loop ((a a)
-             (b b))
-    (if (null? a)
-        #t
-        (if (not (= (car a) (car b)))
-            (< (car a) (car b))
-            (loop (cdr a) (cdr b))))))
+    (define (combination k lst)
+      (cond
+       ((= k 0) '(()))
+       ((null? lst) '())
+       (else
+        (let ((head (car lst))
+              (tail (cdr lst)))
+          (append (map (lambda (y) (cons head y)) (combination (- k 1) tail))
+                  (combination k tail))))))
 
-(define (make-indices n)
-  ;; This is based on:
-  ;;
-  ;;   https://math.stackexchange.com/a/3146793/23663
-  ;;
-  (let* ((tab (iota n))
-         (cx (combination (floor (/ n 2)) tab)))
-    (let loop1 ((cx cx)
-                (out '()))
-      (if (null? cx)
-          (begin (assume (ok? (combinations tab) out))
-                 (sort! out lex<))
-          (let loop2 ((L (map (lambda (i) (cons i (bool (memv i (car cx))))) tab))
-                      (a '())
-                      (b '()))
-            (call-with-values (lambda () (findij L))
-              (lambda (continue? L i j)
-                (if continue?
-                    (loop2 L (cons j a) (cons i b))
-                    (loop1 (cdr cx)
-                           (cons (append (reverse! a) (map car L) (reverse! b))
-                                 out))))))))))
+    (define (combinations lst)
+      (if (null? lst) '(())
+          (let* ((head (car lst))
+                 (tail (cdr lst))
+                 (s (combinations tail))
+                 (v (map (lambda (x) (cons head x)) s)))
+            (append s v))))
 
-(define-record-type <engine>
-  (nstore-engine ref set! rm! prefix)
-  engine?
-  (ref engine-ref)
-  (set! engine-set!)
-  (rm! engine-rm!)
-  (prefix engine-prefix))
+    ;; make-indices will compute the minimum number of indices/tables
+    ;; required to bind any pattern in one hop. The math behind this
+    ;; computation is explained at:
+    ;;
+    ;;   https://math.stackexchange.com/q/3146568/23663
+    ;;
+    ;; make-indices will return the minimum list of permutations in
+    ;; lexicographic order of the base index ie. (iota n) where n is
+    ;; the length of ITEMS ie. the n in nstore.
 
-(define-record-type <nstore>
-  (make-nstore engine prefix indices n)
-  nstore?
-  (engine nstore-engine-ref)
-  (prefix nstore-prefix)
-  (indices nstore-indices)
-  (n nstore-n))
+    (define (prefix? lst other)
+      "Return #t if LST is prefix of OTHER"
+      (let loop ((lst lst)
+                 (other other))
+        (if (null? lst)
+            #t
+            (if (= (car lst) (car other))
+                (loop (cdr lst) (cdr other))
+                #f))))
 
-(define (nstore engine prefix items)
-  (make-nstore engine prefix (make-indices (length items)) (length items)))
+    (define (permutation-prefix? c o)
+      (any (lambda (p) (prefix? p o)) (permutations c)))
 
-(define nstore-ask?
-  (okvs-transactional
-   (lambda (transaction nstore items)
-     (assume (= (length items) (nstore-n nstore)))
-     ;; indices are sorted in lexicographic order, that is the first
-     ;; index is always (iota n) also known as the base index. So that
-     ;; there is no need to permute ITEMS.  zero in the following
-     ;; cons* is the index of the base index in nstore-indices
-     (let ((key (apply pack (cons* (nstore-prefix nstore) 0 items))))
-       (bool ((engine-ref (nstore-engine-ref nstore)) transaction key))))))
+    (define (ok? combinations candidate)
+      (every (lambda (c) (any (lambda (p) (permutation-prefix? c p)) candidate)) combinations))
 
-(define true (pack #t))
+    (define (findij L)
+      (let loop3 ((x L)
+                  (y '()))
+        (if (or (null? x) (null? (cdr x)))
+            (values #f (append (reverse! y) x) #f #f)
+            (if (and (not (cdr (list-ref x 0))) (cdr (list-ref x 1)))
+                (values #t
+                        (append (cddr x) (reverse! y))
+                        (car (list-ref x 0))
+                        (car (list-ref x 1)))
+                (loop3 (cdr x) (cons (car x) y))))))
 
-(define (make-tuple list permutation)
-  ;; Construct a permutation of LIST based on PERMUTATION
-  (let ((tuple (make-vector (length permutation))))
-    (for-each (lambda (index value) (vector-set! tuple index value)) permutation list)
-    (vector->list tuple)))
+    (define (bool v)
+      (not (not v)))
 
-(define (permute items index)
-  (let ((items (list->vector items)))
-    (let loop ((index index)
-               (out '()))
-      (if (null? index)
-          (reverse! out)
-          (loop (cdr index)
-                (cons (vector-ref items (car index)) out))))))
+    (define (lex< a b)
+      (let loop ((a a)
+                 (b b))
+        (if (null? a)
+            #t
+            (if (not (= (car a) (car b)))
+                (< (car a) (car b))
+                (loop (cdr a) (cdr b))))))
 
-(define nstore-add!
-  (okvs-transactional
-   (lambda (transaction nstore items)
-     (assume (= (length items) (nstore-n nstore)))
-     (let ((engine (nstore-engine-ref nstore))
-           (nstore-prefix (nstore-prefix nstore)))
-       ;; add ITEMS into the okvs and prefix each of the permutation
-       ;; of ITEMS with the nstore-prefix and the index of the
-       ;; permutation inside the list INDICES called SUBSPACE.
-       (let loop ((indices (nstore-indices nstore))
-                  (subspace 0))
-         (unless (null? indices)
-           (let ((key (apply pack (cons* nstore-prefix
-                                         subspace
-                                         (permute items (car indices))))))
-             ((engine-set! engine) transaction key true)
-             (loop (cdr indices) (+ 1 subspace)))))))))
+    ;; TODO: memoize, see fstore.scm
+    (define (make-indices n)
+      ;; This is based on:
+      ;;
+      ;;   https://math.stackexchange.com/a/3146793/23663
+      ;;
+      (let* ((tab (iota n))
+             (cx (combination (floor (/ n 2)) tab)))
+        (let loop1 ((cx cx)
+                    (out '()))
+          (if (null? cx)
+              (begin (assert (ok? (combinations tab) out))
+                     (sort! lex< out))
+              (let loop2 ((L (map (lambda (i) (cons i (bool (memv i (car cx))))) tab))
+                          (a '())
+                          (b '()))
+                (call-with-values (lambda () (findij L))
+                  (lambda (continue? L i j)
+                    (if continue?
+                        (loop2 L (cons j a) (cons i b))
+                        (loop1 (cdr cx)
+                               (cons (append (reverse! a) (map car L) (reverse! b))
+                                     out))))))))))
 
-(define nstore-rm!
-  (okvs-transactional
-   (lambda (transaction nstore items)
-     (assume (= (length items) (nstore-n nstore)))
-     (let ((engine (nstore-engine-ref nstore))
-           (nstore-prefix (nstore-prefix nstore)))
-       ;; Similar to the above but remove ITEMS
-       (let loop ((indices (nstore-indices nstore))
-                  (subspace 0))
-         (unless (null? indices)
-           (let ((key (apply pack (cons* nstore-prefix
-                                         subspace
-                                         (make-tuple items (car indices))))))
-             ((engine-rm! engine) transaction key)
-             (loop (cdr indices) (+ subspace 1)))))))))
+    (define-record-type <engine>
+      (nstore-engine ref set! rm! prefix)
+      engine?
+      (ref engine-ref)
+      (set! engine-set!)
+      (rm! engine-rm!)
+      (prefix engine-prefix))
 
-(define-record-type <nstore-var>
-  (nstore-var name)
-  nstore-var?
-  (name nstore-var-name))
+    (define-record-type <nstore>
+      (make-nstore engine prefix indices n)
+      nstore?
+      (engine nstore-engine-ref)
+      (prefix nstore-prefix)
+      (indices nstore-indices)
+      (n nstore-n))
 
-(define (bind* pattern tuple seed)
-  ;; associate variables of PATTERN to value of TUPLE with SEED.
-  (let loop ((tuple tuple)
-             (pattern pattern)
-             (out seed))
-    (if (null? tuple)
-        out
-        (if (nstore-var? (car pattern)) ;; only bind variables
-            (loop (cdr tuple)
-                  (cdr pattern)
-                  (hashmap-set out
-                               (nstore-var-name (car pattern))
-                               (car tuple)))
-            (loop (cdr tuple) (cdr pattern) out)))))
+    (define (nstore engine prefix items)
+      (make-nstore engine prefix (make-indices (length items)) (length items)))
 
-(define (pattern->combination pattern)
-  (let loop ((pattern pattern)
-             (index 0)
-             (out '()))
-    (if (null? pattern)
-        (reverse! out)
-        (loop (cdr pattern)
-              (+ 1 index)
-              (if (nstore-var? (car pattern))
-                  out
-                  (cons index out))))))
+    (define nstore-ask?
+      (okvs-transactional
+       (lambda (transaction nstore items)
+         (assert (= (length items) (nstore-n nstore)))
+         ;; indices are sorted in lexicographic order, that is the first
+         ;; index is always (iota n) also known as the base index. So that
+         ;; there is no need to permute ITEMS.  zero in the following
+         ;; cons* is the index of the base index in nstore-indices
+         (let ((key (apply pack (append (nstore-prefix nstore) (list 0) items))))
+           (bool ((engine-ref (nstore-engine-ref nstore)) transaction key))))))
 
-(define (pattern->index pattern indices)
-  ;; Retrieve the index that will allow to bind pattern in one
-  ;; hop. This is done by getting all non-variable items of the
-  ;; pattern and looking up the first index that is
-  ;; permutation-prefix
-  (let ((combination (pattern->combination pattern)))
-    (let loop ((indices indices)
-               (subspace 0))
-      (if (null? indices)
-          (error 'nstore "oops!")
-          (if (permutation-prefix? combination (car indices))
-              (values (car indices) subspace)
-              (loop (cdr indices) (+ subspace 1)))))))
+    (define true (pack #t))
 
-(define (pattern->prefix pattern index)
-  ;; Return the list that correspond to INDEX, that is the items
-  ;; of PATTERN that are not variables. This is used as the prefix
-  ;; for the range query done later.
-  (let loop ((index index)
-             (out '()))
-    (let ((v (list-ref pattern (car index))))
-      (if (nstore-var? v)
-          (reverse! out)
-          (loop (cdr index) (cons v out))))))
+    (define (make-tuple list permutation)
+      ;; Construct a permutation of LIST based on PERMUTATION
+      (let ((tuple (make-vector (length permutation))))
+        (for-each (lambda (index value) (vector-set! tuple index value)) permutation list)
+        (vector->list tuple)))
 
-(define (%from transaction nstore pattern seed)
-  (call-with-values (lambda () (pattern->index pattern (nstore-indices nstore)))
-    (lambda (index subspace)
-      (let ((prefix (cons* (nstore-prefix nstore) subspace (pattern->prefix pattern index)))
-            (engine (nstore-engine-ref nstore)))
-        (gmap (lambda (pair) (bind* pattern
-                                    (make-tuple (cddr (unpack (car pair))) index)
-                                    seed))
-              ((engine-prefix engine) transaction (apply pack prefix)))))))
+    (define (permute items index)
+      (let ((items (list->vector items)))
+        (let loop ((index index)
+                   (out '()))
+          (if (null? index)
+              (reverse! out)
+              (loop (cdr index)
+                    (cons (vector-ref items (car index)) out))))))
 
-(define comparator (make-eq-comparator))
+    (define nstore-add!
+      (okvs-transactional
+       (lambda (transaction nstore items)
+         (assert (= (length items) (nstore-n nstore)))
+         (let ((engine (nstore-engine-ref nstore))
+               (nstore-prefix (nstore-prefix nstore)))
+           ;; add ITEMS into the okvs and prefix each of the permutation
+           ;; of ITEMS with the nstore-prefix and the index of the
+           ;; permutation inside the list INDICES called SUBSPACE.
+           (let loop ((indices (nstore-indices nstore))
+                      (subspace 0))
+             (unless (null? indices)
+               (let ((key (apply pack (append nstore-prefix
+                                              (list subspace)
+                                              (permute items (car indices))))))
+                 ((engine-set! engine) transaction key true)
+                 (loop (cdr indices) (+ 1 subspace)))))))))
 
-(define nstore-from
-  (okvs-transactional
-   (lambda (transaction nstore pattern)
-     (assume (= (length pattern) (nstore-n nstore)))
-     (%from transaction nstore pattern (hashmap comparator)))))
+    (define nstore-rm!
+      (okvs-transactional
+       (lambda (transaction nstore items)
+         (assert (= (length items) (nstore-n nstore)))
+         (let ((engine (nstore-engine-ref nstore))
+               (nstore-prefix (nstore-prefix nstore)))
+           ;; Similar to the above but remove ITEMS
+           (let loop ((indices (nstore-indices nstore))
+                      (subspace 0))
+             (unless (null? indices)
+               (let ((key (apply pack (append nstore-prefix
+                                              (list subspace)
+                                              (permute items (car indices))))))
+                 ((engine-rm! engine) transaction key)
+                 (loop (cdr indices) (+ subspace 1)))))))))
 
-(define (pattern-bind pattern seed)
-  ;; Return a pattern where variables that have a binding in seed
-  ;; are replaced with the associated value. In pratice, most of
-  ;; the time, it is the same pattern with less variables.
-  (map (lambda (item) (or (and (nstore-var? item)
-                               (hashmap-ref/default seed
-                                                    (nstore-var-name item)
-                                                    #f))
-                          item))
-       pattern))
+    (define-record-type <nstore-var>
+      (nstore-var name)
+      nstore-var?
+      (name nstore-var-name))
 
-(define (gscatter generator)
-  ;; Return a generator that yields the elements of the
-  ;; generators produced by the given generator. Same as gflatten
-  ;; but the generator contains other generators instead of lists.
-  (let ((state eof-object))
-    (lambda ()
-      (let ((value (state)))
-        (if (eof-object? value)
-            (let loop ((new (generator)))
-              (if (eof-object? new)
-                  new
-                  (let ((value (new)))
-                    (if (eof-object? value)
-                        (loop (generator))
-                        (begin (set! state new)
-                               value)))))
-            value)))))
+    (define (bind* pattern tuple seed)
+      ;; associate variables of PATTERN to value of TUPLE with SEED.
+      (let loop ((tuple tuple)
+                 (pattern pattern)
+                 (out seed))
+        (if (null? tuple)
+            out
+            (if (nstore-var? (car pattern)) ;; only bind variables
+                (loop (cdr tuple)
+                      (cdr pattern)
+                      (hashmap-set out
+                                   (nstore-var-name (car pattern))
+                                   (car tuple)))
+                (loop (cdr tuple) (cdr pattern) out)))))
 
-(define nstore-where
-  (okvs-transactional
-   (lambda (transaction nstore pattern)
-     (assume (= (length pattern) (nstore-n nstore)))
-     (lambda (from)
-       (gscatter
-        (gmap (lambda (bindings) (%from transaction
-                                        nstore
-                                        (pattern-bind pattern bindings)
-                                        bindings))
-              from))))))
+    (define (pattern->combination pattern)
+      (let loop ((pattern pattern)
+                 (index 0)
+                 (out '()))
+        (if (null? pattern)
+            (reverse! out)
+            (loop (cdr pattern)
+                  (+ 1 index)
+                  (if (nstore-var? (car pattern))
+                      out
+                      (cons index out))))))
 
-(define-syntax nstore-select
-  (syntax-rules ()
-    ((_ value) value)
-    ((_ value f rest ...)
-     (nstore-select (f value) rest ...))))
+    (define (pattern->index pattern indices)
+      ;; Retrieve the index that will allow to bind pattern in one
+      ;; hop. This is done by getting all non-variable items of the
+      ;; pattern and looking up the first index that is
+      ;; permutation-prefix
+      (let ((combination (pattern->combination pattern)))
+        (let loop ((indices indices)
+                   (subspace 0))
+          (if (null? indices)
+              (error 'nstore "oops!")
+              (if (permutation-prefix? combination (car indices))
+                  (values (car indices) subspace)
+                  (loop (cdr indices) (+ subspace 1)))))))
+
+    (define (pattern->prefix pattern index)
+      ;; Return the list that correspond to INDEX, that is the items
+      ;; of PATTERN that are not variables. This is used as the prefix
+      ;; for the range query done later.
+      (let loop ((index index)
+                 (out '()))
+        (let ((v (list-ref pattern (car index))))
+          (if (nstore-var? v)
+              (reverse! out)
+              (loop (cdr index) (cons v out))))))
+
+    (define (%from transaction nstore pattern seed config)
+      (call-with-values (lambda () (pattern->index pattern (nstore-indices nstore)))
+        (lambda (index subspace)
+          (let ((prefix (append (nstore-prefix nstore)
+                                (list subspace)
+                                (pattern->prefix pattern index)))
+                (engine (nstore-engine-ref nstore)))
+            (gmap (lambda (pair)
+                    (bind* pattern
+                           (make-tuple (cddr (unpack (car pair))) index)
+                           seed))
+                  ((engine-prefix engine) transaction (apply pack prefix) config))))))
+
+    (define comparator (make-eq-comparator))
+
+    (define nstore-from
+      (case-lambda
+        ((transaction nstore pattern)
+         (assert (= (length pattern) (nstore-n nstore)))
+         (%from transaction nstore pattern (hashmap comparator) '()))
+        ((transaction nstore pattern config)
+         (assert (= (length pattern) (nstore-n nstore)))
+         (%from transaction nstore pattern (hashmap comparator) config))))
+
+    (define (pattern-bind pattern seed)
+      ;; Return a pattern where variables that have a binding in seed
+      ;; are replaced with the associated value. In pratice, most of
+      ;; the time, it is the same pattern with less variables.
+      (map (lambda (item) (or (and (nstore-var? item)
+                                   (hashmap-ref/default seed
+                                                        (nstore-var-name item)
+                                                        #f))
+                              item))
+           pattern))
+
+    (define (gscatter generator)
+      ;; Return a generator that yields the elements of the
+      ;; generators produced by the given generator. Same as gflatten
+      ;; but the generator contains other generators instead of lists.
+      (let ((state eof-object))
+        (lambda ()
+          (let ((value (state)))
+            (if (eof-object? value)
+                (let loop ((new (generator)))
+                  (if (eof-object? new)
+                      new
+                      (let ((value (new)))
+                        (if (eof-object? value)
+                            (loop (generator))
+                            (begin (set! state new)
+                                   value)))))
+                value)))))
+
+    (define nstore-where
+      (lambda (transaction nstore pattern)
+        (assert (= (length pattern) (nstore-n nstore)))
+        (lambda (from)
+          (gscatter
+           (gmap (lambda (bindings) (%from transaction
+                                           nstore
+                                           (pattern-bind pattern bindings)
+                                           bindings
+                                           '()))
+                 from)))))
+
+    (define-syntax nstore-select
+      (syntax-rules ()
+        ((_ value) value)
+        ((_ value f rest ...)
+         (nstore-select (f value) rest ...))))))

--- a/srfi/nstore.scm
+++ b/srfi/nstore.scm
@@ -1,293 +1,323 @@
-(define-library (nstore)
-  (export make close transactional everything ask add! rm! var var? var-name from where engine)
+(define-module (nstore))
 
-  (import (scheme base))
-  (import (scheme list))
-  (import (scheme mapping hash))
-  (import (scheme generator))
-  (import (only (okvstore) pack unpack))
+(export nstore-engine nstore nstore-ask? nstore-add! nstore-rm!
+        nstore-var nstore-var? nstore-var-name
+        nstore-from nstore-where nstore-select)
 
-  (begin
+(import (scheme assume))
+(import (scheme base))
+(import (scheme list))
+(import (scheme comparator))
+(import (scheme mapping hash))
+(import (scheme generator))
 
-    ;; helper
+(import (okvs))
+(import (pack))
 
-    (define (assert v msg)
-      (unless v
-        (error 'nstore msg)))
+;; helper
 
-    ;; make-indices will compute the minimum number of indices/tables
-    ;; required to bind any pattern in one hop. The math behind this
-    ;; computation is explained at:
-    ;;
-    ;;   https://math.stackexchange.com/q/3146568/23663
-    ;;
-    ;; make-indices will return the minimum list of permutations in
-    ;; lexicographic order of the base index ie. (iota n) where n is
-    ;; the length of ITEMS ie. the n in nstore.
+(define (permutations s)
+  ;; http://rosettacode.org/wiki/Permutations#Scheme
+  (cond
+   ((null? s) '(()))
+   ((null? (cdr s)) (list s))
+   (else ;; extract each item in list in turn and permutations the rest
+    (let splice ((l '()) (m (car s)) (r (cdr s)))
+      (append
+       (map (lambda (x) (cons m x)) (permutations (append l r)))
+       (if (null? r) '()
+           (splice (cons m l) (car r) (cdr r))))))))
 
-    (define (permutation-prefix? c o)
-      (any (lambda (p) (prefix? p o)) (permutations c)))
+(define (combination k lst)
+  (cond
+   ((= k 0) '(()))
+   ((null? lst) '())
+   (else
+    (let ((head (car lst))
+          (tail (cdr lst)))
+      (append (map (lambda (y) (cons head y)) (combination (- k 1) tail))
+              (combination k tail))))))
 
-    (define (ok? combinations candidate)
-      (every (lambda (c) (any (lambda (p) (permutation-prefix? c p)) candidate)) combinations))
+(define (combinations lst)
+  (if (null? lst) '(())
+      (let* ((head (car lst))
+             (tail (cdr lst))
+             (s (combinations tail))
+             (v (map (lambda (x) (cons head x)) s)))
+        (append s v))))
 
-    (define (findij L)
-      (let loop3 ((x L)
-                  (y '()))
-        (if (or (null? x) (null? (cdr x)))
-            (values #f (append (reverse! y) x) #f #f)
-            (if (and (not (cdr (list-ref x 0))) (cdr (list-ref x 1)))
-                (values #t
-                        (append (cddr x) (reverse! y))
-                        (car (list-ref x 0))
-                        (car (list-ref x 1)))
-                (loop3 (cdr x) (cons (car x) y))))))
+;; make-indices will compute the minimum number of indices/tables
+;; required to bind any pattern in one hop. The math behind this
+;; computation is explained at:
+;;
+;;   https://math.stackexchange.com/q/3146568/23663
+;;
+;; make-indices will return the minimum list of permutations in
+;; lexicographic order of the base index ie. (iota n) where n is
+;; the length of ITEMS ie. the n in nstore.
 
-    (define (bool v)
-      (not (not v)))
+(define (prefix? lst other)
+  "Return #t if LST is prefix of OTHER"
+  (let loop ((lst lst)
+             (other other))
+    (if (null? lst)
+        #t
+        (if (= (car lst) (car other))
+            (loop (cdr lst) (cdr other))
+            #f))))
 
-    (define (lex< a b)
-      (let loop ((a a)
-                 (b b))
-        (if (null? a)
-            #t
-            (if (not (= (car a) (car b)))
-                (< (car a) (car b))
-                (loop (cdr a) (cdr b))))))
+(define (permutation-prefix? c o)
+  (any (lambda (p) (prefix? p o)) (permutations c)))
 
-    (define (make-indices n)
-      ;; This is based on:
-      ;;
-      ;;   https://math.stackexchange.com/a/3146793/23663
-      ;;
-      (let* ((tab (iota n))
-             (cx (combination (floor (/ n 2)) tab)))
-        (let loop1 ((cx cx)
-                    (out '()))
-          (if (null? cx)
-              (begin (assert (ok? (combinations tab) out))
-                     (sort! lex< out))
-              (let loop2 ((L (map (lambda (i) (cons i (bool (memv i (car cx))))) tab))
-                          (a '())
-                          (b '()))
-                (call-with-values (lambda () (findij L))
-                  (lambda (continue? L i j)
-                    (if continue?
-                        (loop2 L (cons j a) (cons i b))
-                        (loop1 (cdr cx)
-                               (cons (append (reverse! a) (map car L) (reverse! b))
-                                     out))))))))))
+(define (ok? combinations candidate)
+  (every (lambda (c) (any (lambda (p) (permutation-prefix? c p)) candidate)) combinations))
 
-    (define-record-type <engine>
-      (engine database close begin! commit! rollback! ref set! rm! range)
-      engine?
-      (database engine-database)
-      (close engine-close)
-      (begin! engine-begin!)
-      (commit! engine-commit!)
-      (rollback! engine-rollback!)
-      (ref engine-ref)
-      (set! engine-set!)
-      (rm! engine-rm!)
-      (range engine-range))
+(define (findij L)
+  (let loop3 ((x L)
+              (y '()))
+    (if (or (null? x) (null? (cdr x)))
+        (values #f (append (reverse! y) x) #f #f)
+        (if (and (not (cdr (list-ref x 0))) (cdr (list-ref x 1)))
+            (values #t
+                    (append (cddr x) (reverse! y))
+                    (car (list-ref x 0))
+                    (car (list-ref x 1)))
+            (loop3 (cdr x) (cons (car x) y))))))
 
-    (define-record-type <nstore>
-      (make-nstore engine indices n)
-      nstore?
-      (engine nstore-engine)
-      (indices nstore-indices)
-      (n nstore-n))
+(define (bool v)
+  (not (not v)))
 
-    (define (make engine . items)
-      (make-nstore engine (make-indices (iota (length items))) (length items)))
+(define (lex< a b)
+  (let loop ((a a)
+             (b b))
+    (if (null? a)
+        #t
+        (if (not (= (car a) (car b)))
+            (< (car a) (car b))
+            (loop (cdr a) (cdr b))))))
 
-    (define (close nstore)
-      (let ((engine (nstore-engine nstore)))
-        ((engine-close engine) (engine-database engine))))
+(define (make-indices n)
+  ;; This is based on:
+  ;;
+  ;;   https://math.stackexchange.com/a/3146793/23663
+  ;;
+  (let* ((tab (iota n))
+         (cx (combination (floor (/ n 2)) tab)))
+    (let loop1 ((cx cx)
+                (out '()))
+      (if (null? cx)
+          (begin (assume (ok? (combinations tab) out))
+                 (sort! out lex<))
+          (let loop2 ((L (map (lambda (i) (cons i (bool (memv i (car cx))))) tab))
+                      (a '())
+                      (b '()))
+            (call-with-values (lambda () (findij L))
+              (lambda (continue? L i j)
+                (if continue?
+                    (loop2 L (cons j a) (cons i b))
+                    (loop1 (cdr cx)
+                           (cons (append (reverse! a) (map car L) (reverse! b))
+                                 out))))))))))
 
-    ;; XXX: I think that is the best course of action would be to
-    ;; extend somehow the okvstore's transaction. For the time being
-    ;; it is (only) wrapped by one more record type.
+(define-record-type <engine>
+  (nstore-engine ref set! rm! prefix)
+  engine?
+  (ref engine-ref)
+  (set! engine-set!)
+  (rm! engine-rm!)
+  (prefix engine-prefix))
 
-    ;; XXX: Maybe generics are the solution, so one might propose an
-    ;; implementation that is forward compatible with them
-    (define-record-type <transaction>
-      (make-transaction transaction nstore)
-      transaction?
-      (transaction transaction-transaction)
-      (nstore transaction-nstore))
+(define-record-type <nstore>
+  (make-nstore engine prefix indices n)
+  nstore?
+  (engine nstore-engine-ref)
+  (prefix nstore-prefix)
+  (indices nstore-indices)
+  (n nstore-n))
 
-    ;; transaction helpers
+(define (nstore engine prefix items)
+  (make-nstore engine prefix (make-indices (length items)) (length items)))
 
-    (define (transaction-indices transaction)
-      (nstore-indices (transaction-nstore transaction)))
+(define nstore-ask?
+  (okvs-transactional
+   (lambda (transaction nstore items)
+     (assume (= (length items) (nstore-n nstore)))
+     ;; indices are sorted in lexicographic order, that is the first
+     ;; index is always (iota n) also known as the base index. So that
+     ;; there is no need to permute ITEMS.  zero in the following
+     ;; cons* is the index of the base index in nstore-indices
+     (let ((key (apply pack (cons* (nstore-prefix nstore) 0 items))))
+       (bool ((engine-ref (nstore-engine-ref nstore)) transaction key))))))
 
-    (define (transaction-n transaction)
-      (nstore-n (transaction-nstore transaction)))
+(define true (pack #t))
 
-    (define (transaction-engine transaction)
-      (nstore-engine (transaction-nstore transaction-nstore)))
+(define (make-tuple list permutation)
+  ;; Construct a permutation of LIST based on PERMUTATION
+  (let ((tuple (make-vector (length permutation))))
+    (for-each (lambda (index value) (vector-set! tuple index value)) permutation list)
+    (vector->list tuple)))
 
-    (define (transactional proc)
-      (lambda (some . args)
-        (cond
-         ((nstore? some)
-          (let* ((nstore some)
-                 (engine (nstore-engine nstore))
-                 (transaction ((engine-begin! engine) (engine-database engine))))
-            ;; TODO: handle exceptions and rollback as necessary
-            (call-with-values (lambda () (apply proc (make-transaction transaction nstore) args))
-              (lambda out
-                ((engine-commit!) transaction)
-                (apply values out)))))
-         ((transaction? some) (apply proc some args))
-         (else (error 'nstore "the first argument must be nstore or transaction")))))
+(define (permute items index)
+  (let ((items (list->vector items)))
+    (let loop ((index index)
+               (out '()))
+      (if (null? index)
+          (reverse! out)
+          (loop (cdr index)
+                (cons (vector-ref items (car index)) out))))))
 
-    (define everything
-      (transactional
-       (lambda (transaction)
-         (let ((engine (nstore-engine nstore)))
-           ;; Retrieve all tuples from the subspace 0 associated with
-           ;; the base index (iota n) which index number is 0
-           (gmap (lambda (pair) (cdr (unpack (car pair))))
-                 ((engine-range nstore) (transaction-transaction transaction) (pack 0)))))))
+(define nstore-add!
+  (okvs-transactional
+   (lambda (transaction nstore items)
+     (assume (= (length items) (nstore-n nstore)))
+     (let ((engine (nstore-engine-ref nstore))
+           (nstore-prefix (nstore-prefix nstore)))
+       ;; add ITEMS into the okvs and prefix each of the permutation
+       ;; of ITEMS with the nstore-prefix and the index of the
+       ;; permutation inside the list INDICES called SUBSPACE.
+       (let loop ((indices (nstore-indices nstore))
+                  (subspace 0))
+         (unless (null? indices)
+           (let ((key (apply pack (cons* nstore-prefix
+                                         subspace
+                                         (permute items (car indices))))))
+             ((engine-set! engine) transaction key true)
+             (loop (cdr indices) (+ 1 subspace)))))))))
 
-    (define ask?
-      (transactional
-       (lambda (transaction . items)
-         (assert (= (length items) (transaction-n transaction)))
-         ;; indices are sorted in lexicographic order, that is the
-         ;; first index is always (iota n) also known as the base
-         ;; index. So that there is no need to permute ITEMS.
-         (let ((key (apply pack (cons 0 items)))
-               (engine (transaction-engine transaction)))
-           (bool ((engine-ref engine) (transaction-transaction transaction) key))))))
+(define nstore-rm!
+  (okvs-transactional
+   (lambda (transaction nstore items)
+     (assume (= (length items) (nstore-n nstore)))
+     (let ((engine (nstore-engine-ref nstore))
+           (nstore-prefix (nstore-prefix nstore)))
+       ;; Similar to the above but remove ITEMS
+       (let loop ((indices (nstore-indices nstore))
+                  (subspace 0))
+         (unless (null? indices)
+           (let ((key (apply pack (cons* nstore-prefix
+                                         subspace
+                                         (make-tuple items (car indices))))))
+             ((engine-rm! engine) transaction key)
+             (loop (cdr indices) (+ subspace 1)))))))))
 
-    (define true (pack #t))
+(define-record-type <nstore-var>
+  (nstore-var name)
+  nstore-var?
+  (name nstore-var-name))
 
-    (define (make-tuple list permutation)
-      ;; Construct a permutation of LIST based on PERMUTATION
-      (let ((tuple (make-vector (length index))))
-        (for-each (lambda (x y) (vector-set! tuple x y)) permutation list)
-        (vector->list tuple)))
+(define (bind* pattern tuple seed)
+  ;; associate variables of PATTERN to value of TUPLE with SEED.
+  (let loop ((tuple tuple)
+             (pattern pattern)
+             (out seed))
+    (if (null? tuple)
+        out
+        (if (nstore-var? (car pattern)) ;; only bind variables
+            (loop (cdr tuple)
+                  (cdr pattern)
+                  (hashmap-set out
+                               (nstore-var-name (car pattern))
+                               (car tuple)))
+            (loop (cdr tuple) (cdr pattern) out)))))
 
-    (define add!
-      (transactional
-       (lambda (transaction . items)
-         (assert (= (length items) (transaction-n transaction)))
-         (let ((engine (transaction-engine transaction)))
-           ;; add ITEMS into the okvstore and prefix each of the
-           ;; permutation of ITEMS with the index of the permutation
-           ;; inside the list INDICES called SUBSPACE.
-           (let loop ((indices (transaction-indices transaction))
-                      (subspace 0))
-             (let ((key (apply pack (cons subspace (make-tuple items (car indices))))))
-               ((engine-add! engine) (transaction-transaction transaction) key true)
-               (loop (cdr indices (+ subspace 1)))))))))
+(define (pattern->combination pattern)
+  (let loop ((pattern pattern)
+             (index 0)
+             (out '()))
+    (if (null? pattern)
+        (reverse! out)
+        (loop (cdr pattern)
+              (+ 1 index)
+              (if (nstore-var? (car pattern))
+                  out
+                  (cons index out))))))
 
-    (define rm!
-      (transactional
-       (lambda (transaction . items)
-         (assert (= (length items) (transaction-n transaction)))
-         (let ((engine (transaction-engine transaction)))
-           ;; Similar as the above but remove ITEMS
-           (let loop ((indices (transaction-indices transaction))
-                      (subspace 0))
-             (let ((key (apply pack (cons subspace (make-tuple items (car indices))))))
-               ((engine-rm! engine) (transaction-transaction transaction) key)))))
-               (loop (cdr indices (+ subspace 1)))))
+(define (pattern->index pattern indices)
+  ;; Retrieve the index that will allow to bind pattern in one
+  ;; hop. This is done by getting all non-variable items of the
+  ;; pattern and looking up the first index that is
+  ;; permutation-prefix
+  (let ((combination (pattern->combination pattern)))
+    (let loop ((indices indices)
+               (subspace 0))
+      (if (null? indices)
+          (error 'nstore "oops!")
+          (if (permutation-prefix? combination (car indices))
+              (values (car indices) subspace)
+              (loop (cdr indices) (+ subspace 1)))))))
 
-    (define-record-type <var>
-      (var name)
-      var?
-      (name var-name))
+(define (pattern->prefix pattern index)
+  ;; Return the list that correspond to INDEX, that is the items
+  ;; of PATTERN that are not variables. This is used as the prefix
+  ;; for the range query done later.
+  (let loop ((index index)
+             (out '()))
+    (let ((v (list-ref pattern (car index))))
+      (if (nstore-var? v)
+          (reverse! out)
+          (loop (cdr index) (cons v out))))))
 
-    (define (bind pattern tuple seed)
-      ;; associate variables of PATTERN to value of TUPLE with SEED.
-      (let loop ((tuple tuple)
-                 (pattern pattern)
-                 (out seed))
-        (if (null? tuple)
-            out
-            (if (var? (car pattern)) ;; only bind variables
-                (loop (cdr tuple)
-                      (cdr pattern)
-                      (hashmap-set out (var-name (car pattern)) (car tuple)))
-                (loop (cdr tuple) (cdr pattern) out)))))
+(define (%from transaction nstore pattern seed)
+  (call-with-values (lambda () (pattern->index pattern (nstore-indices nstore)))
+    (lambda (index subspace)
+      (let ((prefix (cons* (nstore-prefix nstore) subspace (pattern->prefix pattern index)))
+            (engine (nstore-engine-ref nstore)))
+        (gmap (lambda (pair) (bind* pattern
+                                    (make-tuple (cddr (unpack (car pair))) index)
+                                    seed))
+              ((engine-prefix engine) transaction (apply pack prefix)))))))
 
-    (define (pattern->index pattern indices)
-      ;; Retrieve the index that will allow to bind pattern in one
-      ;; hop. This is done by getting all non-variable items of the
-      ;; pattern and looking up the first index that is
-      ;; permutation-prefix
-      (let ((combination (filter (lambda (item) (not (var? item))) pattern)))
-        (let loop ((indices indices)
-                   (subspace 0))
-          (if (null? indices)
-              (error 'nstore "oops!")
-              (if (permutation-prefix? combination (car indices))
-                  (values subspace (car indices))
-                  (loop (+ subspace 1) (cdr indices)))))))
+(define comparator (make-eq-comparator))
 
-    (define (pattern->prefix pattern index)
-      ;; Return the list that correspond to INDEX, that is the items
-      ;; of PATTERN that are not variables. This is used as the prefix
-      ;; for the range query done later.
-      (let loop ((index index)
-                 (out '()))
+(define nstore-from
+  (okvs-transactional
+   (lambda (transaction nstore pattern)
+     (assume (= (length pattern) (nstore-n nstore)))
+     (%from transaction nstore pattern (hashmap comparator)))))
 
-        ;; TODO: not sure about the comment below
+(define (pattern-bind pattern seed)
+  ;; Return a pattern where variables that have a binding in seed
+  ;; are replaced with the associated value. In pratice, most of
+  ;; the time, it is the same pattern with less variables.
+  (map (lambda (item) (or (and (nstore-var? item)
+                               (hashmap-ref/default seed
+                                                    (nstore-var-name item)
+                                                    #f))
+                          item))
+       pattern))
 
-        ;; pattern has at least one variable, otherwise the query
-        ;; would be calling ask? The way the index is constructed with
-        ;; pattern->index, makes it so that when the code reach a
-        ;; variable what remains is the empty list or more variables
-        (let ((v (list-ref pattern (car index))))
-          (if (var? v)
-              (reverse! out)
-              (loop (cdr index) (cons v out))))))
+(define (gscatter generator)
+  ;; Return a generator that yields the elements of the
+  ;; generators produced by the given generator. Same as gflatten
+  ;; but the generator contains other generators instead of lists.
+  (let ((state eof-object))
+    (lambda ()
+      (let ((value (state)))
+        (if (eof-object? value)
+            (let loop ((new (generator)))
+              (if (eof-object? new)
+                  new
+                  (let ((value (new)))
+                    (if (eof-object? value)
+                        (loop (generator))
+                        (begin (set! state new)
+                               value)))))
+            value)))))
 
-    (define (%from transaction pattern seed)
-      (call-with-values (lambda () (pattern->index pattern (transaction-indices transaction)))
-        (lambda (subspace index)
-          (let ((prefix (cons subspace (pattern->prefix pattern index)))
-                (engine (transaction-engine transaction)))
-            (gmap (lambda (pair) (bind pattern
-                                       (make-tuple (cdr (unpack (car pair))) index)
-                                       seed))
-                  ((engine-range nstore) transaction (apply pack prefix)))))))
+(define nstore-where
+  (okvs-transactional
+   (lambda (transaction nstore pattern)
+     (assume (= (length pattern) (nstore-n nstore)))
+     (lambda (from)
+       (gscatter
+        (gmap (lambda (bindings) (%from transaction
+                                        nstore
+                                        (pattern-bind pattern bindings)
+                                        bindings))
+              from))))))
 
-    (define from
-      (transactional
-       (lambda (transaction . pattern)
-         (assert (= (length items) (transaction-n transaction)))
-         (%from transaction pattern (hashmap)))))
-
-    (define (and=> v proc)
-      (if v (proc v) #f))
-
-    (define (pattern-bind pattern seed)
-      ;; Return a pattern where variables that have a binding in seed
-      ;; are replaced with the associated value. In pratice, most of
-      ;; the time, it is the same pattern with less variables.
-      (map (lambda (item) (or (and (var? item)
-                                   (and=> (hashmap-ref/default seed (var-name item) #f) cdr))
-                              item))
-           pattern))
-
-    (define (gscatter generator)
-      ;; Returns a generator that yields the elements of the
-      ;; generators produced by the given generator. Same as gflatten
-      ;; but the generator contains other generators instead of lists.
-      (error 'fixme "not implemented, yet"))
-
-    (define where
-      (transactional
-       (lambda (transaction . pattern)
-         (assert (= (length items) (transaction-n transaction)))
-         (lambda (from)
-           (gscatter
-            (gmap (lambda (bindings) (%from transaction (pattern-bind pattern bindings) bindings))
-                  from))))))
-
-    ))
+(define-syntax nstore-select
+  (syntax-rules ()
+    ((_ value) value)
+    ((_ value f rest ...)
+     (nstore-select (f value) rest ...))))

--- a/srfi/pack.scm
+++ b/srfi/pack.scm
@@ -1,0 +1,264 @@
+;;
+;; Based on:
+;;
+;;   https://github.com/amirouche/hoply/blob/master/hoply/tuple.py
+;;
+;; Which is translated from foundationdb python bindings.
+;;
+(define-module (pack))
+
+(export pack unpack *null*)
+
+(import (scheme base))
+(import (scheme bitwise))
+(import (scheme list))
+(import (scheme generator))
+
+
+(define *null* '(null))
+
+(define *null-code* #x00)
+;; variable length
+(define *bytes-code* #x01)
+(define *string-code* #x02)
+(define *symbol-code* #x03)
+(define *nested-code* #x05)
+;; integers
+(define *neg-int-start* #x0B)
+(define *int-zero-code* #x14)
+(define *pos-int-end* #x1D)
+;; double
+(define *double-code* #x21)
+;; true and false
+(define *false-code* #x26)
+(define *true-code* #x27)
+(define *escape-code* #xFF)
+
+
+;; pack
+
+(define (struct:pack>Q integer)
+  (let ((bytevector (make-bytevector 8 0)))
+    (let loop ((index 0))
+      (unless (= index 8)
+        (bytevector-u8-set! bytevector index (bitwise-and
+                                (arithmetic-shift integer (- (* (- 7 index) 8)))
+                                #xFF))
+        (loop (+ index 1))))
+    bytevector))
+
+(define (struct:unpack>Q bytevector)
+  (let loop ((index 0)
+             (out 0))
+    (if (= index 8)
+        out
+        (loop (+ index 1)
+              (+ out
+                 (arithmetic-shift
+                  (bytevector-u8-ref bytevector index)
+                  (* (- 7 index) 8)))))))
+
+(define (%%pack-bytes bv accumulator)
+  (let loop ((index 0))
+    (unless (= index (bytevector-length bv))
+      (let ((byte (bytevector-u8-ref bv index)))
+        (if (zero? byte)
+            (begin ;; escape null byte
+              (accumulator #x00)
+              (accumulator *escape-code*))
+            (accumulator byte))
+        (loop (+ index 1)))))
+  (accumulator #x00))
+
+(define *bigish* (arithmetic-shift 1 (* 8 8)))
+
+(define *limits*
+  (let ((limits (make-vector 9)))
+    (let loop ((index 0))
+      (unless (= index 9)
+        (vector-set! limits index (- (arithmetic-shift 1 (* index 8)) 1))
+        (loop (+ index 1))))
+    limits))
+
+(define (bisect vector value)
+  (let loop ((low 0)
+             (high (vector-length vector)))
+    (if (>= low high)
+        low
+        (let ((middle (quotient (+ low high) 2)))
+          (if (< (vector-ref vector middle) value)
+              (loop (+ middle 1) high)
+              (loop low middle))))))
+
+(define (%%pack-positive-integer integer accumulator)
+  (if (< integer *bigish*)
+      ;; small integer
+      (let* ((length (integer-length integer))
+             (n (exact (ceiling (/ length 8))))
+             (bv (struct:pack>Q integer)))
+        (accumulator (+ *int-zero-code* n))
+        (let loop ((index (- (bytevector-length bv) n)))
+          (unless (= index (bytevector-length bv))
+            (accumulator (bytevector-u8-ref bv index))
+            (loop (+ index 1)))))
+      ;; big integer
+      (let ((length (exact (floor (/ (+ (integer-length integer) 7) 8)))))
+        (accumulator *pos-int-end*)
+        (accumulator length)
+        (let loop ((index (- length 1)))
+          (unless (= index -1)
+            (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
+                                      #xFF))
+            (loop (- index 1)))))))
+
+(define (%%pack-negative-integer integer accumulator)
+  (if (< (- integer) *bigish*)
+      ;; small negative integer
+      (let* ((n (bisect *limits* (- integer)))
+             (maxv (vector-ref *limits* n))
+             (bv (struct:pack>Q (+ maxv integer))))
+        (accumulator (- *int-zero-code* n))
+        (let loop ((index (- (bytevector-length bv) n)))
+          (unless (= index (bytevector-length bv))
+            (accumulator (bytevector-u8-ref bv index))
+            (loop (+ index 1)))))
+      ;; big negative integer
+      (let* ((length (exact (ceiling (/ (+ (integer-length integer) 7) 8))))
+             (integer (+ integer (- (arithmetic-shift 1 (* length 8)) 1))))
+        (accumulator *neg-int-start*)
+        (accumulator (bitwise-xor length #xFF))
+        (let loop ((index (- length 1)))
+          (unless (= index -1)
+            (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
+                                      #xFF))
+            (loop (- index 1)))))))
+
+(define (%%pack accumulator)
+  (lambda (value)
+    (cond
+     ((eq? value *null*) (accumulator *null-code*))
+     ((eq? value #t) (accumulator *true-code*))
+     ((eq? value #f) (accumulator *false-code*))
+     ((bytevector? value) (accumulator *bytes-code*) (%%pack-bytes value accumulator))
+     ((string? value) (accumulator *string-code*) (%%pack-bytes (string->utf8 value) accumulator))
+     ((symbol? value)
+      (accumulator *symbol-code*)
+      (%%pack-bytes (string->utf8 (symbol->string value)) accumulator))
+     ;; integer
+     ((and (number? value) (exact? value) (< value 0)) (%%pack-negative-integer value accumulator))
+     ((and (number? value) (exact? value) (= value 0)) (accumulator *int-zero-code*))
+     ((and (number? value) (exact? value) (> value 0)) (%%pack-positive-integer value accumulator))
+     ;;
+     (else (error 'pack "unsupported data type" value)))))
+
+(define (%pack args accumulator)
+  (for-each (%%pack accumulator) args))
+
+(define (pack . args)
+  (let ((accumulator (bytevector-accumulator)))
+    (%pack args accumulator)
+    (accumulator (eof-object))))
+
+;; unpack
+
+(define (list->bytevector list)
+  (let ((vec (make-bytevector (length list) 0)))
+    (let loop ((i 0) (list list))
+      (if (null? list)
+          vec
+          (begin
+            (bytevector-u8-set! vec i (car list))
+            (loop (+ i 1) (cdr list)))))))
+
+(define (unpack-bytes bv position)
+  (let loop ((position position)
+             (out '()))
+    (if (zero? (bytevector-u8-ref bv position))
+        (cond
+         ;; end of bv
+         ((= (+ position 1) (bytevector-length bv))
+          (values (list->bytevector (reverse! out)) (+ position 1)))
+         ;; escaped null bytes
+         ((= (bytevector-u8-ref bv (+ position 1)) *escape-code*)
+          (loop (+ position 2) (cons #x00 out)))
+         ;; end of string
+         (else (values (list->bytevector (reverse! out)) (+ position 1))))
+        ;; just a byte
+        (loop (+ position 1) (cons (bytevector-u8-ref bv position) out)))))
+
+(define (unpack-positive-integer bv code position)
+  (let* ((n (- code 20))
+         (sub (make-bytevector 8 0)))
+    (let loop ((index 0))
+      (unless (= index n)
+        (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
+        (loop (+ index 1))))
+    (values (struct:unpack>Q sub) (+ position 1 n))))
+
+(define (unpack-negative-integer bv code position)
+  (let* ((n (- 20 code))
+         (maxv (vector-ref *limits* n))
+         (sub (make-bytevector 8 0)))
+    (let loop ((index 0))
+      (unless (= index n)
+        (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
+        (loop (+ index 1))))
+    (values (- (struct:unpack>Q sub) maxv) (+ position 1 n))))
+
+(define (unpack-bigish-positive-integer bv code position)
+  (let ((length (bytevector-u8-ref bv (+ position 1))))
+    (values (let loop ((range (iota length))
+                       (out 0))
+              (if (null? range)
+                  out
+                  (loop (cdr range) (+ (arithmetic-shift out 8)
+                                       (bytevector-u8-ref bv (+ position 2 (car range)))))))
+            (+ position 2 length))))
+
+(define (unpack-bigish-negative-integer bv code position)
+  (let ((length (bitwise-xor (bytevector-u8-ref bv (+ position 1)) #xFF)))
+    (values (let loop ((range (iota length))
+                       (out 0))
+              (if (null? range)
+                  (+ (- out (arithmetic-shift 1 (* length 8))) 1)
+                  (loop (cdr range) (+ (arithmetic-shift out 8)
+                                       (bytevector-u8-ref bv (+ position 2 (car range)))))))
+            (+ position 2 length))))
+
+(define (unpack bv)
+  (let loop ((position 0)
+             (out '()))
+    (if (= position (bytevector-length bv))
+        (reverse! out)
+        (let ((code (bytevector-u8-ref bv position)))
+          (cond
+           ;; null, true, false and zero
+           ((= code *null-code*) (loop (+ position 1) (cons *null* out)))
+           ((= code *true-code*) (loop (+ position 1) (cons #t out)))
+           ((= code *false-code*) (loop (+ position 1) (cons #f out)))
+           ((= code *int-zero-code*) (loop (+ position 1) (cons 0 out)))
+           ;; variable length
+           ((= code *bytes-code*)
+            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+              (lambda (value position) (loop position (cons value out)))))
+           ((= code *string-code*)
+            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+              (lambda (value position) (loop position (cons (utf8->string value) out)))))
+           ((= code *symbol-code*)
+            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+              (lambda (value position) (loop position (cons (string->symbol (utf8->string value)) out)))))
+           ;; integers
+           ((and (> code *int-zero-code*) (< code *pos-int-end*))
+            (call-with-values (lambda () (unpack-positive-integer bv code position))
+              (lambda (value position) (loop position (cons value out)))))
+           ((and (> code *neg-int-start*) (< code *int-zero-code*))
+            (call-with-values (lambda () (unpack-negative-integer bv code position))
+              (lambda (value position) (loop position (cons value out)))))
+           ((= code *pos-int-end*)
+            (call-with-values (lambda () (unpack-bigish-positive-integer bv code position))
+              (lambda (value position) (loop position (cons value out)))))
+           ((= code *neg-int-start*)
+            (call-with-values (lambda () (unpack-bigish-negative-integer bv code position))
+              (lambda (value position) (loop position (cons value out)))))
+           ;; oops
+           (else (error 'unpack "unsupported code" code)))))))

--- a/srfi/pack.scm
+++ b/srfi/pack.scm
@@ -1,264 +1,273 @@
+;; Copyright © 2019 Amirouche BOUBEKKI <amirouche at hyper dev>
 ;;
-;; Based on:
+;;; Comment:
+;;
+;; - 2019/05: initial version
+;; - 2019/05: import from guile-wiredtiger
+;;
+;;; Based on:
 ;;
 ;;   https://github.com/amirouche/hoply/blob/master/hoply/tuple.py
 ;;
 ;; Which is translated from foundationdb python bindings.
 ;;
-(define-module (pack))
+(define-library (pack)
 
-(export pack unpack *null*)
+  (export pack unpack *null*)
 
-(import (scheme base))
-(import (scheme bitwise))
-(import (scheme list))
-(import (scheme generator))
+  (import (scheme base))
+  (import (scheme bitwise))
+  (import (scheme list))
+  (import (scheme generator))
+
+  (begin
+
+    (define *null* '(null))
+
+    (define *null-code* #x00)
+    ;; variable length
+    (define *bytes-code* #x01)
+    (define *string-code* #x02)
+    (define *symbol-code* #x03)
+    (define *nested-code* #x05)
+    ;; integers
+    (define *neg-int-start* #x0B)
+    (define *int-zero-code* #x14)
+    (define *pos-int-end* #x1D)
+    ;; double
+    (define *double-code* #x21)
+    ;; true and false
+    (define *false-code* #x26)
+    (define *true-code* #x27)
+    (define *escape-code* #xFF)
 
 
-(define *null* '(null))
+    ;; pack
 
-(define *null-code* #x00)
-;; variable length
-(define *bytes-code* #x01)
-(define *string-code* #x02)
-(define *symbol-code* #x03)
-(define *nested-code* #x05)
-;; integers
-(define *neg-int-start* #x0B)
-(define *int-zero-code* #x14)
-(define *pos-int-end* #x1D)
-;; double
-(define *double-code* #x21)
-;; true and false
-(define *false-code* #x26)
-(define *true-code* #x27)
-(define *escape-code* #xFF)
+    (define (struct:pack>Q integer)
+      (let ((bytevector (make-bytevector 8 0)))
+        (let loop ((index 0))
+          (unless (= index 8)
+            (bytevector-u8-set! bytevector index (bitwise-and
+                                                  (arithmetic-shift integer (- (* (- 7 index) 8)))
+                                                  #xFF))
+            (loop (+ index 1))))
+        bytevector))
 
+    (define (struct:unpack>Q bytevector)
+      (let loop ((index 0)
+                 (out 0))
+        (if (= index 8)
+            out
+            (loop (+ index 1)
+                  (+ out
+                     (arithmetic-shift
+                      (bytevector-u8-ref bytevector index)
+                      (* (- 7 index) 8)))))))
 
-;; pack
-
-(define (struct:pack>Q integer)
-  (let ((bytevector (make-bytevector 8 0)))
-    (let loop ((index 0))
-      (unless (= index 8)
-        (bytevector-u8-set! bytevector index (bitwise-and
-                                (arithmetic-shift integer (- (* (- 7 index) 8)))
-                                #xFF))
-        (loop (+ index 1))))
-    bytevector))
-
-(define (struct:unpack>Q bytevector)
-  (let loop ((index 0)
-             (out 0))
-    (if (= index 8)
-        out
-        (loop (+ index 1)
-              (+ out
-                 (arithmetic-shift
-                  (bytevector-u8-ref bytevector index)
-                  (* (- 7 index) 8)))))))
-
-(define (%%pack-bytes bv accumulator)
-  (let loop ((index 0))
-    (unless (= index (bytevector-length bv))
-      (let ((byte (bytevector-u8-ref bv index)))
-        (if (zero? byte)
-            (begin ;; escape null byte
-              (accumulator #x00)
-              (accumulator *escape-code*))
-            (accumulator byte))
-        (loop (+ index 1)))))
-  (accumulator #x00))
-
-(define *bigish* (arithmetic-shift 1 (* 8 8)))
-
-(define *limits*
-  (let ((limits (make-vector 9)))
-    (let loop ((index 0))
-      (unless (= index 9)
-        (vector-set! limits index (- (arithmetic-shift 1 (* index 8)) 1))
-        (loop (+ index 1))))
-    limits))
-
-(define (bisect vector value)
-  (let loop ((low 0)
-             (high (vector-length vector)))
-    (if (>= low high)
-        low
-        (let ((middle (quotient (+ low high) 2)))
-          (if (< (vector-ref vector middle) value)
-              (loop (+ middle 1) high)
-              (loop low middle))))))
-
-(define (%%pack-positive-integer integer accumulator)
-  (if (< integer *bigish*)
-      ;; small integer
-      (let* ((length (integer-length integer))
-             (n (exact (ceiling (/ length 8))))
-             (bv (struct:pack>Q integer)))
-        (accumulator (+ *int-zero-code* n))
-        (let loop ((index (- (bytevector-length bv) n)))
-          (unless (= index (bytevector-length bv))
-            (accumulator (bytevector-u8-ref bv index))
+    (define (%%pack-bytes bv accumulator)
+      (let loop ((index 0))
+        (unless (= index (bytevector-length bv))
+          (let ((byte (bytevector-u8-ref bv index)))
+            (if (zero? byte)
+                (begin ;; escape null byte
+                  (accumulator #x00)
+                  (accumulator *escape-code*))
+                (accumulator byte))
             (loop (+ index 1)))))
-      ;; big integer
-      (let ((length (exact (floor (/ (+ (integer-length integer) 7) 8)))))
-        (accumulator *pos-int-end*)
-        (accumulator length)
-        (let loop ((index (- length 1)))
-          (unless (= index -1)
-            (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
-                                      #xFF))
-            (loop (- index 1)))))))
+      (accumulator #x00))
 
-(define (%%pack-negative-integer integer accumulator)
-  (if (< (- integer) *bigish*)
-      ;; small negative integer
-      (let* ((n (bisect *limits* (- integer)))
-             (maxv (vector-ref *limits* n))
-             (bv (struct:pack>Q (+ maxv integer))))
-        (accumulator (- *int-zero-code* n))
-        (let loop ((index (- (bytevector-length bv) n)))
-          (unless (= index (bytevector-length bv))
-            (accumulator (bytevector-u8-ref bv index))
-            (loop (+ index 1)))))
-      ;; big negative integer
-      (let* ((length (exact (ceiling (/ (+ (integer-length integer) 7) 8))))
-             (integer (+ integer (- (arithmetic-shift 1 (* length 8)) 1))))
-        (accumulator *neg-int-start*)
-        (accumulator (bitwise-xor length #xFF))
-        (let loop ((index (- length 1)))
-          (unless (= index -1)
-            (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
-                                      #xFF))
-            (loop (- index 1)))))))
+    (define *bigish* (arithmetic-shift 1 (* 8 8)))
 
-(define (%%pack accumulator)
-  (lambda (value)
-    (cond
-     ((eq? value *null*) (accumulator *null-code*))
-     ((eq? value #t) (accumulator *true-code*))
-     ((eq? value #f) (accumulator *false-code*))
-     ((bytevector? value) (accumulator *bytes-code*) (%%pack-bytes value accumulator))
-     ((string? value) (accumulator *string-code*) (%%pack-bytes (string->utf8 value) accumulator))
-     ((symbol? value)
-      (accumulator *symbol-code*)
-      (%%pack-bytes (string->utf8 (symbol->string value)) accumulator))
-     ;; integer
-     ((and (number? value) (exact? value) (< value 0)) (%%pack-negative-integer value accumulator))
-     ((and (number? value) (exact? value) (= value 0)) (accumulator *int-zero-code*))
-     ((and (number? value) (exact? value) (> value 0)) (%%pack-positive-integer value accumulator))
-     ;;
-     (else (error 'pack "unsupported data type" value)))))
+    (define *limits*
+      (let ((limits (make-vector 9)))
+        (let loop ((index 0))
+          (unless (= index 9)
+            (vector-set! limits index (- (arithmetic-shift 1 (* index 8)) 1))
+            (loop (+ index 1))))
+        limits))
 
-(define (%pack args accumulator)
-  (for-each (%%pack accumulator) args))
+    (define (bisect vector value)
+      (let loop ((low 0)
+                 (high (vector-length vector)))
+        (if (>= low high)
+            low
+            (let ((middle (quotient (+ low high) 2)))
+              (if (< (vector-ref vector middle) value)
+                  (loop (+ middle 1) high)
+                  (loop low middle))))))
 
-(define (pack . args)
-  (let ((accumulator (bytevector-accumulator)))
-    (%pack args accumulator)
-    (accumulator (eof-object))))
+    (define (%%pack-positive-integer integer accumulator)
+      (if (< integer *bigish*)
+          ;; small integer
+          (let* ((length (integer-length integer))
+                 (n (exact (ceiling (/ length 8))))
+                 (bv (struct:pack>Q integer)))
+            (accumulator (+ *int-zero-code* n))
+            (let loop ((index (- (bytevector-length bv) n)))
+              (unless (= index (bytevector-length bv))
+                (accumulator (bytevector-u8-ref bv index))
+                (loop (+ index 1)))))
+          ;; big integer
+          (let ((length (exact (floor (/ (+ (integer-length integer) 7) 8)))))
+            (accumulator *pos-int-end*)
+            (accumulator length)
+            (let loop ((index (- length 1)))
+              (unless (= index -1)
+                (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
+                                          #xFF))
+                (loop (- index 1)))))))
 
-;; unpack
+    (define (%%pack-negative-integer integer accumulator)
+      (if (< (- integer) *bigish*)
+          ;; small negative integer
+          (let* ((n (bisect *limits* (- integer)))
+                 (maxv (vector-ref *limits* n))
+                 (bv (struct:pack>Q (+ maxv integer))))
+            (accumulator (- *int-zero-code* n))
+            (let loop ((index (- (bytevector-length bv) n)))
+              (unless (= index (bytevector-length bv))
+                (accumulator (bytevector-u8-ref bv index))
+                (loop (+ index 1)))))
+          ;; big negative integer
+          (let* ((length (exact (ceiling (/ (+ (integer-length integer) 7) 8))))
+                 (integer (+ integer (- (arithmetic-shift 1 (* length 8)) 1))))
+            (accumulator *neg-int-start*)
+            (accumulator (bitwise-xor length #xFF))
+            (let loop ((index (- length 1)))
+              (unless (= index -1)
+                (accumulator (bitwise-and (arithmetic-shift integer (- (* 8 index)))
+                                          #xFF))
+                (loop (- index 1)))))))
 
-(define (list->bytevector list)
-  (let ((vec (make-bytevector (length list) 0)))
-    (let loop ((i 0) (list list))
-      (if (null? list)
-          vec
-          (begin
-            (bytevector-u8-set! vec i (car list))
-            (loop (+ i 1) (cdr list)))))))
-
-(define (unpack-bytes bv position)
-  (let loop ((position position)
-             (out '()))
-    (if (zero? (bytevector-u8-ref bv position))
+    (define (%%pack accumulator)
+      (lambda (value)
         (cond
-         ;; end of bv
-         ((= (+ position 1) (bytevector-length bv))
-          (values (list->bytevector (reverse! out)) (+ position 1)))
-         ;; escaped null bytes
-         ((= (bytevector-u8-ref bv (+ position 1)) *escape-code*)
-          (loop (+ position 2) (cons #x00 out)))
-         ;; end of string
-         (else (values (list->bytevector (reverse! out)) (+ position 1))))
-        ;; just a byte
-        (loop (+ position 1) (cons (bytevector-u8-ref bv position) out)))))
+         ((eq? value *null*) (accumulator *null-code*))
+         ((eq? value #t) (accumulator *true-code*))
+         ((eq? value #f) (accumulator *false-code*))
+         ((bytevector? value) (accumulator *bytes-code*) (%%pack-bytes value accumulator))
+         ((string? value) (accumulator *string-code*) (%%pack-bytes (string->utf8 value) accumulator))
+         ((symbol? value)
+          (accumulator *symbol-code*)
+          (%%pack-bytes (string->utf8 (symbol->string value)) accumulator))
+         ;; integer
+         ((and (number? value) (exact? value) (< value 0)) (%%pack-negative-integer value accumulator))
+         ((and (number? value) (exact? value) (= value 0)) (accumulator *int-zero-code*))
+         ((and (number? value) (exact? value) (> value 0)) (%%pack-positive-integer value accumulator))
+         ;;
+         (else (error 'pack "unsupported data type" value)))))
 
-(define (unpack-positive-integer bv code position)
-  (let* ((n (- code 20))
-         (sub (make-bytevector 8 0)))
-    (let loop ((index 0))
-      (unless (= index n)
-        (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
-        (loop (+ index 1))))
-    (values (struct:unpack>Q sub) (+ position 1 n))))
+    (define (%pack args accumulator)
+      (for-each (%%pack accumulator) args))
 
-(define (unpack-negative-integer bv code position)
-  (let* ((n (- 20 code))
-         (maxv (vector-ref *limits* n))
-         (sub (make-bytevector 8 0)))
-    (let loop ((index 0))
-      (unless (= index n)
-        (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
-        (loop (+ index 1))))
-    (values (- (struct:unpack>Q sub) maxv) (+ position 1 n))))
+    (define (pack . args)
+      (let ((accumulator (bytevector-accumulator)))
+        (%pack args accumulator)
+        (accumulator (eof-object))))
 
-(define (unpack-bigish-positive-integer bv code position)
-  (let ((length (bytevector-u8-ref bv (+ position 1))))
-    (values (let loop ((range (iota length))
-                       (out 0))
-              (if (null? range)
-                  out
-                  (loop (cdr range) (+ (arithmetic-shift out 8)
-                                       (bytevector-u8-ref bv (+ position 2 (car range)))))))
-            (+ position 2 length))))
+    ;; unpack
 
-(define (unpack-bigish-negative-integer bv code position)
-  (let ((length (bitwise-xor (bytevector-u8-ref bv (+ position 1)) #xFF)))
-    (values (let loop ((range (iota length))
-                       (out 0))
-              (if (null? range)
-                  (+ (- out (arithmetic-shift 1 (* length 8))) 1)
-                  (loop (cdr range) (+ (arithmetic-shift out 8)
-                                       (bytevector-u8-ref bv (+ position 2 (car range)))))))
-            (+ position 2 length))))
+    (define (list->bytevector list)
+      (let ((vec (make-bytevector (length list) 0)))
+        (let loop ((i 0) (list list))
+          (if (null? list)
+              vec
+              (begin
+                (bytevector-u8-set! vec i (car list))
+                (loop (+ i 1) (cdr list)))))))
 
-(define (unpack bv)
-  (let loop ((position 0)
-             (out '()))
-    (if (= position (bytevector-length bv))
-        (reverse! out)
-        (let ((code (bytevector-u8-ref bv position)))
-          (cond
-           ;; null, true, false and zero
-           ((= code *null-code*) (loop (+ position 1) (cons *null* out)))
-           ((= code *true-code*) (loop (+ position 1) (cons #t out)))
-           ((= code *false-code*) (loop (+ position 1) (cons #f out)))
-           ((= code *int-zero-code*) (loop (+ position 1) (cons 0 out)))
-           ;; variable length
-           ((= code *bytes-code*)
-            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
-              (lambda (value position) (loop position (cons value out)))))
-           ((= code *string-code*)
-            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
-              (lambda (value position) (loop position (cons (utf8->string value) out)))))
-           ((= code *symbol-code*)
-            (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
-              (lambda (value position) (loop position (cons (string->symbol (utf8->string value)) out)))))
-           ;; integers
-           ((and (> code *int-zero-code*) (< code *pos-int-end*))
-            (call-with-values (lambda () (unpack-positive-integer bv code position))
-              (lambda (value position) (loop position (cons value out)))))
-           ((and (> code *neg-int-start*) (< code *int-zero-code*))
-            (call-with-values (lambda () (unpack-negative-integer bv code position))
-              (lambda (value position) (loop position (cons value out)))))
-           ((= code *pos-int-end*)
-            (call-with-values (lambda () (unpack-bigish-positive-integer bv code position))
-              (lambda (value position) (loop position (cons value out)))))
-           ((= code *neg-int-start*)
-            (call-with-values (lambda () (unpack-bigish-negative-integer bv code position))
-              (lambda (value position) (loop position (cons value out)))))
-           ;; oops
-           (else (error 'unpack "unsupported code" code)))))))
+    (define (unpack-bytes bv position)
+      (let loop ((position position)
+                 (out '()))
+        (if (zero? (bytevector-u8-ref bv position))
+            (cond
+             ;; end of bv
+             ((= (+ position 1) (bytevector-length bv))
+              (values (list->bytevector (reverse! out)) (+ position 1)))
+             ;; escaped null bytes
+             ((= (bytevector-u8-ref bv (+ position 1)) *escape-code*)
+              (loop (+ position 2) (cons #x00 out)))
+             ;; end of string
+             (else (values (list->bytevector (reverse! out)) (+ position 1))))
+            ;; just a byte
+            (loop (+ position 1) (cons (bytevector-u8-ref bv position) out)))))
+
+    (define (unpack-positive-integer bv code position)
+      (let* ((n (- code 20))
+             (sub (make-bytevector 8 0)))
+        (let loop ((index 0))
+          (unless (= index n)
+            (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
+            (loop (+ index 1))))
+        (values (struct:unpack>Q sub) (+ position 1 n))))
+
+    (define (unpack-negative-integer bv code position)
+      (let* ((n (- 20 code))
+             (maxv (vector-ref *limits* n))
+             (sub (make-bytevector 8 0)))
+        (let loop ((index 0))
+          (unless (= index n)
+            (bytevector-u8-set! sub (+ (- 8 n) index) (bytevector-u8-ref bv (+ position 1 index)))
+            (loop (+ index 1))))
+        (values (- (struct:unpack>Q sub) maxv) (+ position 1 n))))
+
+    (define (unpack-bigish-positive-integer bv code position)
+      (let ((length (bytevector-u8-ref bv (+ position 1))))
+        (values (let loop ((range (iota length))
+                           (out 0))
+                  (if (null? range)
+                      out
+                      (loop (cdr range) (+ (arithmetic-shift out 8)
+                                           (bytevector-u8-ref bv (+ position 2 (car range)))))))
+                (+ position 2 length))))
+
+    (define (unpack-bigish-negative-integer bv code position)
+      (let ((length (bitwise-xor (bytevector-u8-ref bv (+ position 1)) #xFF)))
+        (values (let loop ((range (iota length))
+                           (out 0))
+                  (if (null? range)
+                      (+ (- out (arithmetic-shift 1 (* length 8))) 1)
+                      (loop (cdr range) (+ (arithmetic-shift out 8)
+                                           (bytevector-u8-ref bv (+ position 2 (car range)))))))
+                (+ position 2 length))))
+
+    (define (unpack bv)
+      (let loop ((position 0)
+                 (out '()))
+        (if (= position (bytevector-length bv))
+            (reverse! out)
+            (let ((code (bytevector-u8-ref bv position)))
+              (cond
+               ;; null, true, false and zero
+               ((= code *null-code*) (loop (+ position 1) (cons *null* out)))
+               ((= code *true-code*) (loop (+ position 1) (cons #t out)))
+               ((= code *false-code*) (loop (+ position 1) (cons #f out)))
+               ((= code *int-zero-code*) (loop (+ position 1) (cons 0 out)))
+               ;; variable length
+               ((= code *bytes-code*)
+                (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+                  (lambda (value position) (loop position (cons value out)))))
+               ((= code *string-code*)
+                (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+                  (lambda (value position) (loop position (cons (utf8->string value) out)))))
+               ((= code *symbol-code*)
+                (call-with-values (lambda () (unpack-bytes bv (+ position 1)))
+                  (lambda (value position) (loop position (cons (string->symbol (utf8->string value)) out)))))
+               ;; integers
+               ((and (> code *int-zero-code*) (< code *pos-int-end*))
+                (call-with-values (lambda () (unpack-positive-integer bv code position))
+                  (lambda (value position) (loop position (cons value out)))))
+               ((and (> code *neg-int-start*) (< code *int-zero-code*))
+                (call-with-values (lambda () (unpack-negative-integer bv code position))
+                  (lambda (value position) (loop position (cons value out)))))
+               ((= code *pos-int-end*)
+                (call-with-values (lambda () (unpack-bigish-positive-integer bv code position))
+                  (lambda (value position) (loop position (cons value out)))))
+               ((= code *neg-int-start*)
+                (call-with-values (lambda () (unpack-bigish-negative-integer bv code position))
+                  (lambda (value position) (loop position (cons value out)))))
+               ;; oops
+               (else (error 'unpack "unsupported code" code)))))))
+
+    ))


### PR DESCRIPTION
Summary of changes:

- okvs must manage the transaction

- `nstore-everything` was removed and replaced by `okvs-debug`

- `nstore` takes a prefix parameter that must be a list, to allow to use the same okvs to store multiple abstractions.

- tuple items are passed as list instead of rest parameters

- Actually, allow pagination but without support for `reverse?` because the order in which bindings are returned is not predictable (except if you forced a particular index). That is `nstore-from` only support `offset` and `limit`.

- `nstore-from` and `nstore-where` are not decorated with `okvs-transactional` because it would give the false impression that it is useable as-is in the REPL. Unlike the other procedures in this specification, this two procedure return generator which "valid" as long as the transaction is running. Once the transaction is commited or rollbacked, it is not anymore possible to retrieve the results.

- Update sample code